### PR TITLE
Unique check containers for time resource

### DIFF
--- a/monitor.yml
+++ b/monitor.yml
@@ -246,7 +246,7 @@ jobs:
           }
           fly -t ci sync
           fly -t ci destroy-pipeline -n -p new-pipeline
-          fly -t ci set-pipeline -n -p new-pipeline -c oxygen-mask/pipeline.yml
+          fly -t ci set-pipeline -n -p new-pipeline -c oxygen-mask/pipeline.yml -v param="create-and-run-new-pipeline"
           fly -t ci unpause-pipeline -p new-pipeline
 
           until [ "$(fly -t ci builds -j new-pipeline/auto-triggering | grep -v pending | wc -l)" -gt 0 ]; do

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,7 +1,9 @@
 resources:
 - name: time-trigger
   type: time
-  source: {interval: 24h}
+  source:
+    interval: 24h
+    unique: ((param))
 
 jobs:
 - name: simple-job

--- a/scripts/setup
+++ b/scripts/setup
@@ -43,7 +43,7 @@ set -x
 if [ -n "$DELETE_THE_PIPELINES" ]; then
   fly -t "$MONITORED_TARGET" destroy-pipeline -n -p "$PIPELINE_NAME"
 fi
-fly -t "$MONITORED_TARGET" set-pipeline -n -p "$PIPELINE_NAME" -c pipeline.yml
+fly -t "$MONITORED_TARGET" set-pipeline -n -p "$PIPELINE_NAME" -c pipeline.yml -v param="$PIPELINE_NAME"
 fly -t "$MONITORED_TARGET" unpause-pipeline -p "$PIPELINE_NAME"
 fly -t "$MONITORED_TARGET" expose-pipeline -p "$PIPELINE_NAME"
 


### PR DESCRIPTION
Added a unique parameter into the time resource configuration for the
SLI jobs. This will ensure that the time resource will have it's own
check container so that it will not need to compete with other resources
to run a check. 